### PR TITLE
Fixed vertical SSAO blur

### DIFF
--- a/shaders/ssao.fx
+++ b/shaders/ssao.fx
@@ -317,7 +317,7 @@ float4 BlurSSAO(VS_OUTPUT_POSTFX i) : SV_Target
     keyPassThrough = temp.KEY_COMPONENTS;
 #endif
 
-    float key = unpackKey(keyPassThrough);
+    float key = unpackKey(temp.KEY_COMPONENTS);
 
     float sum = temp.VALUE_COMPONENTS;
 


### PR DESCRIPTION
During the vertical pass, `key` didn't get a valid depth-value because of the `#ifdef`-disabled passthrough above---resulting in the pass being essentially disabled. See http://i.imgur.com/IPme7lD.png (right is with this fix).

The original SAO-paper always does the passthrough (no `#ifdef HORIZONTAL` above), but since you made the change I just updated `unpackKey` instead of removing the `#ifdef`. Doesn't matter either way I think. :)
