### PR TITLE
Add InvariantCulture to avoid FormatException

### DIFF
--- a/Framework parts/ShaderManager.cs
+++ b/Framework parts/ShaderManager.cs
@@ -167,7 +167,7 @@ namespace CSharpRenderer
                     if (matchGlobalDefineRegex.Success)
                     {
                         string defineName = matchGlobalDefineRegex.Groups[1].Value;
-                        float value = Single.Parse(matchGlobalDefineRegex.Groups[2].Value);
+                        float value = Single.Parse(matchGlobalDefineRegex.Groups[2].Value, CultureInfo.InvariantCulture);
 
                         if (m_GlobalDefineValues.ContainsKey(defineName))
                         {


### PR DESCRIPTION
Hi,

I just wanted to let you know that I had this exception on my french Windows because by default the decimal
separator is ',' and not '.' .
I got it working by adding CultureInfo.InvariantCulture. I thought it might help.

By the way, thanks for sharing :) !
